### PR TITLE
Add tsmatch JSONPath operator for granular Full Text Search

### DIFF
--- a/doc/src/sgml/func/func-json.sgml
+++ b/doc/src/sgml/func/func-json.sgml
@@ -3107,6 +3107,40 @@ ERROR:  jsonpath member accessor can only be applied to an object
         <returnvalue>[]</returnvalue>
        </para></entry>
       </row>
+      <row>
+       <entry role="func_table_entry"><para role="func_signature">
+        <replaceable>string</replaceable> <literal>tsmatch</literal> <replaceable>string</replaceable>
+        <optional> <literal>tsconfig</literal> <replaceable>string</replaceable> </optional>
+        <optional> <literal>tsqparser</literal> <replaceable>string</replaceable> </optional>
+        <returnvalue>boolean</returnvalue>
+       </para>
+        <para>
+         Tests whether the JSON string (first operand) matches the full-text search query
+         (second operand). The matching behavior can be customized using the optional
+         <literal>tsconfig</literal> and <literal>tsqparser</literal> clauses.
+         If <literal>tsconfig</literal> is omitted, the current session's default text search configuration
+         is used (see <xref linkend="guc-default-text-search-config"/>).
+         The <literal>tsqparser</literal> clause determines how the query string is parsed
+         (see <xref linkend="textsearch-parsing-queries"/>).
+         Valid options are <literal>"pl"</literal> (<function>plainto_tsquery</function>),
+         <literal>"ph"</literal> (<function>phraseto_tsquery</function>), and
+         <literal>"w"</literal> (<function>websearch_to_tsquery</function>).
+         If <literal>tsqparser</literal> is omitted, the query is parsed using <function>to_tsquery</function>.
+        </para>
+        <para>
+         <literal>jsonb_path_query_array('["running", "runs", "ran", "jogging"]', '$[*] ? (@ tsmatch "run" tsconfig "english")')</literal>
+         <returnvalue>["running", "runs"]</returnvalue>
+        </para>
+        <para>
+         <literal>jsonb_path_query_array('["fast car", "slow car", "fast and furious"]', '$[*] ? (@ tsmatch "fast &amp; car")')</literal>
+         <returnvalue>["fast car"]</returnvalue>
+        </para>
+        <para>
+         <literal>jsonb_path_query_array('["fast car", "slow car", "fast and furious"]', '$[*] ? (@ tsmatch "fast car" tsqparser "w")')</literal>
+         <returnvalue>["fast car"]</returnvalue>
+        </para>
+       </entry>
+      </row>
      </tbody>
     </tgroup>
    </table>

--- a/src/backend/utils/adt/jsonpath_scan.l
+++ b/src/backend/utils/adt/jsonpath_scan.l
@@ -427,10 +427,13 @@ static const JsonPathKeyword keywords[] = {
 	{7, false, DECIMAL_P, "decimal"},
 	{7, false, INTEGER_P, "integer"},
 	{7, false, TIME_TZ_P, "time_tz"},
+	{7, false, TSMATCH_P, "tsmatch"},
 	{7, false, UNKNOWN_P, "unknown"},
 	{8, false, DATETIME_P, "datetime"},
 	{8, false, KEYVALUE_P, "keyvalue"},
+	{8, false, TSCONFIG_P, "tsconfig"},
 	{9, false, TIMESTAMP_P, "timestamp"},
+	{9, false, TSQUERYPARSER_P, "tsqparser"},
 	{10, false, LIKE_REGEX_P, "like_regex"},
 	{12, false, TIMESTAMP_TZ_P, "timestamp_tz"},
 };

--- a/src/include/utils/jsonpath.h
+++ b/src/include/utils/jsonpath.h
@@ -104,6 +104,7 @@ typedef enum JsonPathItemType
 	jpiLast,					/* LAST array subscript */
 	jpiStartsWith,				/* STARTS WITH predicate */
 	jpiLikeRegex,				/* LIKE_REGEX predicate */
+	jpiTsMatch,					/* TSMATCH predicate */
 	jpiBigint,					/* .bigint() item method */
 	jpiBoolean,					/* .boolean() item method */
 	jpiDate,					/* .date() item method */
@@ -188,6 +189,15 @@ typedef struct JsonPathItem
 			int32		patternlen;
 			uint32		flags;
 		}			like_regex;
+		struct
+		{
+			int32		doc;
+			char	   *tsquery;
+			uint32		tsquerylen;
+			int32		tsconfig;
+			char	   *tsqparser;
+			uint32		tsqparser_len;
+		}			tsmatch;
 	}			content;
 } JsonPathItem;
 
@@ -266,6 +276,15 @@ struct JsonPathParseItem
 			uint32		len;
 			char	   *val;	/* could not be not null-terminated */
 		}			string;
+		struct
+		{
+			JsonPathParseItem *doc;
+			char	   *tsquery;
+			uint32		tsquerylen;
+			JsonPathParseItem *tsconfig;
+			char	   *tsqparser;
+			uint32		tsqparser_len;
+		}			tsmatch;
 	}			value;
 };
 

--- a/src/test/regress/expected/jsonb_jsonpath.out
+++ b/src/test/regress/expected/jsonb_jsonpath.out
@@ -4510,3 +4510,61 @@ ORDER BY s1.num, s2.num;
  {"s": "B"}    | {"s": "B"}    | false | true  | true  | true  | false
 (144 rows)
 
+select jsonb_path_query('[null, 1, "running", "runs", "ran", "run", "runner", "jogging"]', 'lax $[*] ? (@ tsmatch "fly" tsconfig "english")');
+ jsonb_path_query 
+------------------
+(0 rows)
+
+select jsonb_path_query('[null, 1, "running", "runs", "ran", "run", "runner", "jogging"]', 'lax $[*] ? (@ tsmatch "run" tsconfig "english")');
+ jsonb_path_query 
+------------------
+ "running"
+ "runs"
+ "run"
+(3 rows)
+
+select jsonb_path_query('[null, 1, "running", "runs", "ran", "run", "runner", "jogging"]', 'lax $[*] ? (@ tsmatch "run" tsconfig "simple")');
+ jsonb_path_query 
+------------------
+ "run"
+(1 row)
+
+select jsonb_path_query('[null, 1, "PostgreSQL", "postgres", "POSTGRES", "database"]', 'lax $[*] ? (@ tsmatch "Postgres" tsconfig "english")');
+ jsonb_path_query 
+------------------
+ "postgres"
+ "POSTGRES"
+(2 rows)
+
+select jsonb_path_query('[null, 1, "PostgreSQL", "postgres", "POSTGRES", "database"]', 'lax $[*] ? (@ tsmatch "Postgres" tsconfig "simple")');
+ jsonb_path_query 
+------------------
+ "postgres"
+ "POSTGRES"
+(2 rows)
+
+-- in the default tsqparser (to_tsquery) spaces are not allowed, so this should fail for syntax
+select jsonb_path_query('["fast car", "super fast car", "fast and furious", "slow car"]', 'lax $[*] ? (@ tsmatch "fast car" tsconfig "english")');
+ERROR:  syntax error in tsquery: "fast car"
+-- if we specify "w" however it should be ok
+select jsonb_path_query('["fast car", "super fast car", "fast and furious", "slow car"]', 'lax $[*] ? (@ tsmatch "fast car" tsconfig "english" tsqparser "w")');
+ jsonb_path_query 
+------------------
+ "fast car"
+ "super fast car"
+(2 rows)
+
+-- it should also be ok if we change to a valid to_tsquery
+select jsonb_path_query('["fast car", "super fast car", "fast and furious", "slow car"]', 'lax $[*] ? (@ tsmatch "fast & car" tsconfig "english")');
+ jsonb_path_query 
+------------------
+ "fast car"
+ "super fast car"
+(2 rows)
+
+select jsonb_path_query('["fat cat", "cat fat", "fat rats"]', 'lax $[*] ? (@ tsmatch "fat & rat" tsconfig "english")');
+ jsonb_path_query 
+------------------
+ "fat rats"
+(1 row)
+

--- a/src/test/regress/expected/jsonpath.out
+++ b/src/test/regress/expected/jsonpath.out
@@ -1294,3 +1294,63 @@ FROM unnest(ARRAY['$ ? (@ like_regex "pattern" flag "smixq")'::text,
  1a                                        | f  | 42601          | trailing junk after numeric literal at or near "1a" of jsonpath input |                                                          | 
 (5 rows)
 
+-- tsmatch (Full Text Search)
+-- basic success
+select '$ ? (@ tsmatch "simple")'::jsonpath;
+        jsonpath        
+------------------------
+ $?(@ tsmatch "simple")
+(1 row)
+
+select '$ ? (@ tsmatch "running" tsconfig "english")'::jsonpath;
+                  jsonpath                  
+--------------------------------------------
+ $?(@ tsmatch "running" tsconfig "english")
+(1 row)
+
+-- w/out tsconfig and tsqparser
+select '$ ? (@ tsmatch "fast & furious" tsconfig "simple")'::jsonpath;
+                     jsonpath                     
+--------------------------------------------------
+ $?(@ tsmatch "fast & furious" tsconfig "simple")
+(1 row)
+
+select '$ ? (@ tsmatch "fast & furious" tsconfig "simple" tsqparser "w")'::jsonpath;
+                            jsonpath                            
+----------------------------------------------------------------
+ $?(@ tsmatch "fast & furious" tsconfig "simple" tsqparser "w")
+(1 row)
+
+-- tsconfig must be specified first and then tsqparser
+select '$ ? (@ tsmatch "fast & furious" tsqparser "w" tsconfig "simple" )'::jsonpath;
+ERROR:  syntax error at or near " " of jsonpath input
+LINE 1: select '$ ? (@ tsmatch "fast & furious" tsqparser "w" tsconf...
+               ^
+select '$ ? (@ tsmatch "fast & furious" tsqparser "w")'::jsonpath;
+                   jsonpath                   
+----------------------------------------------
+ $?(@ tsmatch "fast & furious" tsqparser "w")
+(1 row)
+
+select '$[*] ? (@.title tsmatch "god" && @.rating > 5)'::jsonpath;
+                     jsonpath                     
+--------------------------------------------------
+ $[*]?(@."title" tsmatch "god" && @."rating" > 5)
+(1 row)
+
+select '$ ? (@ tsmatch $pattern)'::jsonpath;
+ERROR:  syntax error at or near "$pattern" of jsonpath input
+LINE 1: select '$ ? (@ tsmatch $pattern)'::jsonpath;
+               ^
+-- only string literals (no variables) are allowed for tsquery
+select '$ ? (@ tsmatch $var tsconfig "english")'::jsonpath;
+ERROR:  syntax error at or near "$var" of jsonpath input
+LINE 1: select '$ ? (@ tsmatch $var tsconfig "english")'::jsonpath;
+               ^
+-- if a tsconfig doesn't exist it should parse nonetheless (executor will fail it)
+select '$ ? (@ tsmatch "running" tsconfig "wrongconfig")'::jsonpath;
+                    jsonpath                    
+------------------------------------------------
+ $?(@ tsmatch "running" tsconfig "wrongconfig")
+(1 row)
+

--- a/src/test/regress/sql/jsonb_jsonpath.sql
+++ b/src/test/regress/sql/jsonb_jsonpath.sql
@@ -1147,3 +1147,16 @@ SELECT
 	jsonb_path_query_first(s1.j, '$.s > $s', vars => s2.j) gt
 FROM str s1, str s2
 ORDER BY s1.num, s2.num;
+
+select jsonb_path_query('[null, 1, "running", "runs", "ran", "run", "runner", "jogging"]', 'lax $[*] ? (@ tsmatch "fly" tsconfig "english")');
+select jsonb_path_query('[null, 1, "running", "runs", "ran", "run", "runner", "jogging"]', 'lax $[*] ? (@ tsmatch "run" tsconfig "english")');
+select jsonb_path_query('[null, 1, "running", "runs", "ran", "run", "runner", "jogging"]', 'lax $[*] ? (@ tsmatch "run" tsconfig "simple")');
+select jsonb_path_query('[null, 1, "PostgreSQL", "postgres", "POSTGRES", "database"]', 'lax $[*] ? (@ tsmatch "Postgres" tsconfig "english")');
+select jsonb_path_query('[null, 1, "PostgreSQL", "postgres", "POSTGRES", "database"]', 'lax $[*] ? (@ tsmatch "Postgres" tsconfig "simple")');
+-- in the default tsqparser (to_tsquery) spaces are not allowed, so this should fail for syntax
+select jsonb_path_query('["fast car", "super fast car", "fast and furious", "slow car"]', 'lax $[*] ? (@ tsmatch "fast car" tsconfig "english")');
+-- if we specify "w" however it should be ok
+select jsonb_path_query('["fast car", "super fast car", "fast and furious", "slow car"]', 'lax $[*] ? (@ tsmatch "fast car" tsconfig "english" tsqparser "w")');
+-- it should also be ok if we change to a valid to_tsquery
+select jsonb_path_query('["fast car", "super fast car", "fast and furious", "slow car"]', 'lax $[*] ? (@ tsmatch "fast & car" tsconfig "english")');
+select jsonb_path_query('["fat cat", "cat fat", "fat rats"]', 'lax $[*] ? (@ tsmatch "fat & rat" tsconfig "english")');

--- a/src/test/regress/sql/jsonpath.sql
+++ b/src/test/regress/sql/jsonpath.sql
@@ -265,3 +265,22 @@ FROM unnest(ARRAY['$ ? (@ like_regex "pattern" flag "smixq")'::text,
                   '00',
                   '1a']) str,
      LATERAL pg_input_error_info(str, 'jsonpath') as errinfo;
+
+-- tsmatch (Full Text Search)
+
+-- basic success
+select '$ ? (@ tsmatch "simple")'::jsonpath;
+select '$ ? (@ tsmatch "running" tsconfig "english")'::jsonpath;
+-- w/out tsconfig and tsqparser
+select '$ ? (@ tsmatch "fast & furious" tsconfig "simple")'::jsonpath;
+select '$ ? (@ tsmatch "fast & furious" tsconfig "simple" tsqparser "w")'::jsonpath;
+-- tsconfig must be specified first and then tsqparser
+select '$ ? (@ tsmatch "fast & furious" tsqparser "w" tsconfig "simple" )'::jsonpath;
+select '$ ? (@ tsmatch "fast & furious" tsqparser "w")'::jsonpath;
+select '$[*] ? (@.title tsmatch "god" && @.rating > 5)'::jsonpath;
+select '$ ? (@ tsmatch $pattern)'::jsonpath;
+
+-- only string literals (no variables) are allowed for tsquery
+select '$ ? (@ tsmatch $var tsconfig "english")'::jsonpath;
+-- if a tsconfig doesn't exist it should parse nonetheless (executor will fail it)
+select '$ ? (@ tsmatch "running" tsconfig "wrongconfig")'::jsonpath;


### PR DESCRIPTION
This patch introduces the tsmatch boolean operator to the JSONPath engine. By integrating FTS natively into path expressions, this operator allows for high-precision filtering of nested JSONB structures—solving issues with structural ambiguity and query complexity.

Currently, users must choose between two suboptimal paths for searching nested JSON:

1. Imprecise Global Indexing jsonb_to_tsvector aggregates text into a flat vector. This ignores JSON boundaries, leading to false positives when the same key (e.g., "body") appears in different contexts (e.g., a "Product Description" vs. a "Customer Review").

2. Complex SQL Workarounds Achieving 100% precision requires "exploding" the document via jsonb_array_elements and LATERAL joins. This leads to verbose SQL and high memory overhead from generating intermediate heap tuples.

One of the most significant advantages of tsmatch is its ability to participate in multi-condition predicates within the same JSON object— something jsonb_to_tsvector cannot do.

  SELECT jsonb_path_query(doc, '$.comments[*] ? (@.user == "Alice" && @.body tsmatch "performance")');

In a flat vector, the association between "Alice" and "performance" is lost. tsmatch preserves this link by evaluating the FTS predicate in-place during path traversal.

While the SQL/JSON standard (ISO/IEC 9075-2) does not explicitly define an FTS operator, tsmatch is architecturally modeled after the standard-defined like_regex.

The operator supports optional configuration for both the dictionary and the query parser:

  @ tsmatch "query" [ tsconfig "regconfig" ] [ tsqparser "mode" ]

Supported parser modes are:
 - "pl": plainto_tsquery (no operators required)
 - "ph": phraseto_tsquery
 - "w":  websearch_to_tsquery
 - Omitted: Defaults to to_tsquery (strict mode)

The implementation relies on GIN path-matching for index pruning and heap re-checks for precision. Caching is scoped to the JsonPathExecContext, ensuring 'compile-once' efficiency for the tsquery and OID lookup per execution, respecting the stability requirements of prepared statements.